### PR TITLE
Add version requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Metabigor is Intelligence tool, its goal is to do OSINT tasks and more but witho
 
 ## Installation
 
+Ensure Go is version 1.15.2 or higher
+
 ```
 GO111MODULE=on go get github.com/j3ssie/metabigor
 ```


### PR DESCRIPTION
Installing with a version < 1.15.2 is throwing an error installing the hash/maphash package. This fix worked for me.

https://github.com/mattermost/mattermost-server/issues/15337