### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Metabigor is Intelligence tool, its goal is to do OSINT tasks and more but witho
 ## Installation
 
 ```
-GO111MODULE=on go get github.com/j3ssie/metabigor
+GO111MODULE=on go install github.com/j3ssie/metabigor@latest
 ```
 
 ## Main features


### PR DESCRIPTION
Installing executables with "go get" in module mode is deprecated.
"go install pkg@version" should be used instead.
For more information, see https://golang.org/doc/go-get-install-deprecation